### PR TITLE
fix: Removing env setting for babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-event",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Azure Function to process Vet Vists back office events",
   "author": "Defra",
   "contributors": [
@@ -53,10 +53,6 @@
     ]
   },
   "babel": {
-    "env": {
-      "test": {
-        "plugins": ["@babel/plugin-transform-modules-commonjs"]
-      }
-    }
+    "plugins": ["@babel/plugin-transform-modules-commonjs"]
   }
 }


### PR DESCRIPTION
We dont actually need an env setting for the babel config, as we always want it to transform the jest tests into commonJS, in every environment.